### PR TITLE
Add -Wa,-mrelax-relocations=no to CFLAGS for druntime and phobos

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,6 +59,7 @@ parts:
     makefile: posix.mak
     make-parameters:
     - DMD=../../dmd/build/src/dmd
+    - CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H -Wa,-mrelax-relocations=no
     organize:
       src/druntime/import: import/druntime
     stage:
@@ -78,6 +79,7 @@ parts:
     - DMD=../../dmd/build/src/dmd
     - DRUNTIME_PATH=../../druntime/build
     - VERSION=../../dmd/build/VERSION
+    - CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H -Wa,-mrelax-relocations=no
     organize:
       linux/lib32: lib32
       linux/lib64: lib64


### PR DESCRIPTION
This should address the finnicky binutils issues observed when the snap package is installed on Ubuntu 14.04.  See:
https://bugs.launchpad.net/snapcraft/+bug/1668424
https://github.com/ldc-developers/ldc2.snap/issues/17
https://github.com/ldc-developers/ldc2.snap/pull/20

... for discussion of a similar issue encountered with the LDC snap package.

This should fix https://github.com/dlang-snaps/dmd.snap/issues/2.