### PR TITLE
Add -O3 to the CFLAGS used to build druntime and phobos

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,7 +59,7 @@ parts:
     makefile: posix.mak
     make-parameters:
     - DMD=../../dmd/build/src/dmd
-    - CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H -Wa,-mrelax-relocations=no
+    - CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H -O3 -Wa,-mrelax-relocations=no
     organize:
       src/druntime/import: import/druntime
     stage:
@@ -79,7 +79,7 @@ parts:
     - DMD=../../dmd/build/src/dmd
     - DRUNTIME_PATH=../../druntime/build
     - VERSION=../../dmd/build/VERSION
-    - CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H -Wa,-mrelax-relocations=no
+    - CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H -O3 -Wa,-mrelax-relocations=no
     organize:
       linux/lib32: lib32
       linux/lib64: lib64


### PR DESCRIPTION
This patch manually restores the -O3 flag lost due to the changes made in commit 966f523452610181b8fcc1ab5ff18fb657b749c9, which adds explicit `CFLAGS` for the druntime and phobos `make-parameters`.  For the reasons behind this change, see https://github.com/dlang-snaps/dmd.snap/pull/3.

Normally, `posix.mak` starts with a default set of `CFLAGS` which are then extended with `-g` or `-O3` depending on whether we are making a debug or release build.  However, if we explicitly specify `CFLAGS` when invoking the makefile, `posix.mak` takes this as a hard override and no longer adds in the `-O3` option.  We therefore need to manually include it in our custom `CFLAGS`.