### PR TITLE
Use PIC=-fPIC when building druntime and phobos

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -80,6 +80,7 @@ parts:
     - DRUNTIME_PATH=../../druntime/build
     - VERSION=../../dmd/build/VERSION
     - CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H -O3 -Wa,-mrelax-relocations=no
+    - PIC=-fPIC
     organize:
       linux/lib32: lib32
       linux/lib64: lib64
@@ -101,6 +102,7 @@ parts:
     makefile: posix.mak
     make-parameters:
     - DMD=../../../stage/bin/dmd
+    - PIC=-fPIC
     build-packages:
     - libcurl4-gnutls-dev
     stage:


### PR DESCRIPTION
This should ensure that these libraries work on systems such as Ubuntu 16.10 or later, which expect position-independent code.