### PR TITLE
Fix issues with PIC on distros where it is mandatory

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -60,6 +60,7 @@ parts:
     make-parameters:
     - DMD=../../dmd/build/src/dmd
     - CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H -O3 -Wa,-mrelax-relocations=no
+    - PIC=1
     organize:
       src/druntime/import: import/druntime
     stage:
@@ -102,7 +103,6 @@ parts:
     makefile: posix.mak
     make-parameters:
     - DMD=../../../stage/bin/dmd
-    - PIC=1
     build-packages:
     - libcurl4-gnutls-dev
     stage:


### PR DESCRIPTION
By default programs use the static phobos library which when not fully
compiled with -fPIC leads to problems on some distros. Using the shared
phobos library workarounds this because it is fully compiled with PIC.

The problem was simply that the static druntime library was not compiled
with PIC. Before this commit, on distros where PIC is mandatory
snapcraft manages to build dmd, druntime and phobos successfully, but not
the tools repo. Now this is fixed.

Additionally, the 'PIC=1' parameter is noop on the tools repo, becuase
it is not handled by posix.mak. It is actually unnecessary because
the tools makefile allows dmd to pickup the dmd.conf file (not the
case for druntime and phobos build) which already has PIC enabled.