### PR TITLE
Update to 2.074.1 stable release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dmd
-version: 2.074.0
+version: 2.074.1
 summary: Reference compiler for the D programming language
 description: |
     DMD ('Digital Mars D') is the reference compiler for the D
@@ -27,7 +27,7 @@ apps:
 parts:
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.074.0
+    source-tag: &dmd-version v2.074.1
     source-type: git
     plugin: make
     makefile: posix.mak


### PR DESCRIPTION
This point release fixes several regressions, as well as removing the outdated backend license file.  For a list of all fixes, see:
https://dlang.org/changelog/2.074.1.html