### PR TITLE
Add prepare: scriptlet to ensure dmd VERSION file is correct

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,7 @@ parts:
     make-parameters:
     - AUTO_BOOTSTRAP=1
     - RELEASE=1
+    prepare: echo $(git describe) | cut -d v -f 2- | tee VERSION
     organize:
       linux/bin32: bin
       linux/bin64: bin


### PR DESCRIPTION
The VERSION file in the dmd source is used to set version information in the compiler itself (i.e. the output of the `dmd --version` command) but cannot be relied upon to match the actual git tag.  See:
https://issues.dlang.org/show_bug.cgi?id=15910

The `prepare:` scriptlet introduced in this patch overwrites the default VERSION file in the dmd source with the results of `git describe`, with the `v` prefix removed.  This should ensure that the version reported by the packaged compiler always matches the git tag.  Note that this should also make it easier to identify problems if the choice of git source is incorrect in any way.

Besides being generally useful in terms of guaranteeing correct version information for the compiler, this fixes the particular issue that the VERSION file for dmd v2.074.1 source continues to contain `2.074.0` and not the correct compiler version.