### PR TITLE
Update to 2.075.0-b4 development release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dmd
-version: 2.074.1
+version: 2.075.0-b4
 summary: Reference compiler for the D programming language
 description: |
     DMD ('Digital Mars D') is the reference compiler for the D
@@ -9,7 +9,7 @@ description: |
     dustmite, and ddemangle) are also included.
 
 confinement: classic
-grade: stable
+grade: devel
 
 apps:
   dmd:
@@ -27,7 +27,7 @@ apps:
 parts:
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.074.1
+    source-tag: &dmd-version v2.075.0-b4
     source-type: git
     plugin: make
     makefile: posix.mak


### PR DESCRIPTION
Besides the version update, the package has been switched to `devel` grade, meaning it will only be available in the `edge` and `beta` channels of the snap store.