### PR TITLE
Update to 2.075.0 final release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dmd
-version: 2.075.0-b4
+version: 2.075.0
 summary: Reference compiler for the D programming language
 description: |
     DMD ('Digital Mars D') is the reference compiler for the D
@@ -9,7 +9,7 @@ description: |
     dustmite, and ddemangle) are also included.
 
 confinement: classic
-grade: devel
+grade: stable
 
 apps:
   dmd:
@@ -27,7 +27,7 @@ apps:
 parts:
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.075.0-b4
+    source-tag: &dmd-version v2.075.0
     source-type: git
     plugin: make
     makefile: posix.mak


### PR DESCRIPTION
Besides the version update, the package has been returned to a `stable` grade, meaning it is possible in principle to promote this version to the `candidate` and `stable` channels of the snap store.