### PR TITLE
Update to 2.076.0 stable release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dmd
-version: 2.075.1
+version: 2.076.0
 summary: Reference compiler for the D programming language
 description: |
     DMD ('Digital Mars D') is the reference compiler for the D
@@ -27,14 +27,13 @@ apps:
 parts:
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.075.1
+    source-tag: &dmd-version v2.076.0
     source-type: git
     plugin: make
     makefile: posix.mak
     make-parameters:
     - AUTO_BOOTSTRAP=1
     - RELEASE=1
-    prepare: echo $(git describe) | cut -d v -f 2- | tee VERSION
     organize:
       linux/bin32: bin
       linux/bin64: bin
@@ -59,7 +58,7 @@ parts:
     plugin: make
     makefile: posix.mak
     make-parameters:
-    - DMD=../../dmd/build/src/dmd
+    - DMD_DIR=../../dmd/build
     - CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H -O3 -Wa,-mrelax-relocations=no
     - PIC=1
     organize:
@@ -78,7 +77,7 @@ parts:
     plugin: make
     makefile: posix.mak
     make-parameters:
-    - DMD=../../dmd/build/src/dmd
+    - DMD_DIR=../../dmd/build
     - DRUNTIME_PATH=../../druntime/build
     - VERSION=../../dmd/build/VERSION
     - CFLAGS=$(MODEL_FLAG) -fPIC -DHAVE_UNISTD_H -O3 -Wa,-mrelax-relocations=no
@@ -103,7 +102,9 @@ parts:
     plugin: make
     makefile: posix.mak
     make-parameters:
-    - DMD=../../../stage/bin/dmd
+    - DMD_DIR=../../dmd/build
+    - DRUNTIME_PATH=../../druntime/build
+    - PHOBOS_PATH=../../phobos/build
     build-packages:
     - libcurl4-gnutls-dev
     stage:


### PR DESCRIPTION
This patch brings the packaged dmd, druntime, phobos and tools up to date with the latest stable release.

The v2.076.0 release includes some changes to how the library and tools makefiles select the DMD with which to build: instead of the old `DMD` variable pointing to the compiler executable, a new `DMD_DIR` variable pointing to the compiler location is expected/preferred.  The affected parts' `make-parameters` have been updated accordingly, including the addition of correct `DRUNTIME_PATH` and `PHOBOS_PATH` values for the `tools` part.

The `dmd` part's `prepare:` script has also been removed: `git describe` output is now preferred over the contents of the `VERSION` file, so the latter no longer needs to be overwritten.  (The latter is now checked to be correct by the D release process, so should itself also be reliable.)

@MartinNowak apologies that this is a little delayed.  You might want to check that all looks as expected in terms of how the build parameters are set, given the amount that has changed in the various projects' build scripts (very positively, from my point of view:-).