### PR TITLE
Update to 2.078.3 stable release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dmd
-version: 2.078.2
+version: 2.078.3
 summary: Reference compiler for the D programming language
 description: |
     DMD ('Digital Mars D') is the reference compiler for the D
@@ -27,7 +27,7 @@ apps:
 parts:
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.078.2
+    source-tag: &dmd-version v2.078.3
     source-type: git
     plugin: make
     makefile: posix.mak


### PR DESCRIPTION
This brings everything up to date with the latest patch release:
https://dlang.org/changelog/2.078.3.html