### PR TITLE
Update to 2.081.1 stable release

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dmd
-version: 2.080.1
+version: 2.081.1
 summary: Reference compiler for the D programming language
 description: |
     DMD ('Digital Mars D') is the reference compiler for the D
@@ -27,13 +27,13 @@ apps:
 parts:
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.080.1
+    source-tag: &dmd-version v2.081.1
     source-type: git
     plugin: make
     makefile: posix.mak
     make-parameters:
     - AUTO_BOOTSTRAP=1
-    - RELEASE=1
+    - ENABLE_RELEASE=1
     organize:
       linux/bin32: bin
       linux/bin64: bin


### PR DESCRIPTION
Besides the version update, we need to tweak the dmd build flags to replace `RELEASE=1` with `ENABLE_RELEASE=1`.

https://dlang.org/changelog/2.081.1.html
https://github.com/dlang/dmd/releases/tag/v2.081.1