### PR TITLE
Remove aliases from snap package definition

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,13 +16,10 @@ apps:
     command: bin/dmd
   ddemangle:
     command: bin/ddemangle
-    aliases: [ddemangle]
   dustmite:
     command: bin/dustmite
-    aliases: [dustmite]
   rdmd:
     command: bin/rdmd
-    aliases: [rdmd]
 
 parts:
   dmd:


### PR DESCRIPTION
Aliases in the package definition have been deprecated since snapcraft v2.35 (released 2017-11-16).  See also the deprecation notice published at https://docs.snapcraft.io/deprecation-notices/dn5.

They have been maintained until now in order to support distros using older versions of `snapd` that do not support store- or user-defined aliases, but since all supported distros now seem to be using recent enough `snapd` releases, we can drop the aliases at last.