### PR TITLE
Revert "Removed the hack for the soname symlink"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,6 +93,13 @@ parts:
     stage:
     - -linux
     - -src
+    override-build: |
+      snapcraftctl build
+      [ -d ../install/linux/lib32 ] && SO_FILE_32=$(find ../install/linux/lib32/* -name "libphobos2.so.[0-9]*.[0-9]*.[0-9]*")
+      [ -d ../install/linux/lib64 ] && SO_FILE_64=$(find ../install/linux/lib64/* -name "libphobos2.so.[0-9]*.[0-9]*.[0-9]*")
+      [ -d ../install/linux/lib32 ] && [ -f $SO_FILE_32 ] && ln -sfr $SO_FILE_32 ${SO_FILE_32%.*}
+      [ -d ../install/linux/lib64 ] && [ -f $SO_FILE_64 ] && ln -sfr $SO_FILE_64 ${SO_FILE_64%.*}
+      exit 0
     build-packages:
     - gcc
     after:


### PR DESCRIPTION
This reverts commit 81121388003524852b37a72a0506bfa3da2c5c15.

Upstream phobos still does not generate the symlink, even though the PR adding it was merged before the 2.086.0 release.  We therefore need to keep this workaround in the snap package.